### PR TITLE
Make assert tolerant to numerical errors

### DIFF
--- a/globes/projection.py
+++ b/globes/projection.py
@@ -171,8 +171,8 @@ class Face(object):
         b = factor * (cos_angle_v - np.cos(self.angle)*cos_angle_u) / size
         
         # check the lcs coordinates are within the triagle face
-        assert(a >= 0 and b >= 0)
-        assert((a + b) <= 1.0)
+        assert((a >= 0. or np.isclose(a, 0.)) and (b >= 0. or np.isclose(b,0.)))
+        assert((a + b) <= 1.0 or np.isclose(a+b, 1.0))
         return (a, b)
     
     def lcs_to_global(self, point):


### PR DESCRIPTION
This assert failed on my system (Mac, conda 4.3.21, python 3.6.1, 112.1), with `a==-7.4014868308343778e-17`. Probably that's close enough to `0` for the assert to pass.